### PR TITLE
fix env variable that stores redis version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 
 before_script:
 # start custom redis instance
-- export REDIS_VERSION=$(redis-server --version)
+- export REDIS_VERSION="$(redis-server --version)"
 - export REDIS_PORT=6379 REDIS_SOCKET=/tmp/aioredis.sock
 - >
   redis-server --daemonize yes


### PR DESCRIPTION
Environment variable _REDIS_VERSION_ does not contain proper value:

``` bash
% echo $REDIS_VERSION 
Redis
```

when expected string should look like:

``` bash
% echo $REDIS_VERSION 
Redis server v=2.8.11 sha=00000000:0 malloc=jemalloc-3.2.0 bits=64 build=61c7634f4beeb6af
```

so here tiny fix. Please review.
