### PR TITLE
proper test for blocking commands

### DIFF
--- a/tests/list_commands_test.py
+++ b/tests/list_commands_test.py
@@ -124,9 +124,7 @@ class ListCommandsTest(BaseTest):
             self.redis.brpop(key1, key2, timeout=1), loop=self.loop)
         test_value = yield from waiter
         self.assertEqual(test_value, None)
-
         other_redis.close()
-
 
     @run_until_complete
     def test_brpoplpush(self):
@@ -189,7 +187,6 @@ class ListCommandsTest(BaseTest):
         test_value = yield from waiter
         self.assertEqual(test_value, None)
         other_redis.close()
-
 
     @run_until_complete
     def test_lindex(self):


### PR DESCRIPTION
Here my attempt to fix tests for blocking commands. I do not know why, but it is not possible to create other connection inside test:

``` python
other_redis = yield from create_redis('localhost', self.redis_port, loop=self.loop)
```

results in:

``` python
  File "tests/_testutil.py", line 18, in wrapper
    ret = loop.run_until_complete(fun(test, *args, **kw))
  File "/usr/lib/python3.4/asyncio/base_events.py", line 208, in run_until_complete
    return future.result()
  File "/usr/lib/python3.4/asyncio/futures.py", line 243, in result
    raise self._exception
  File "/usr/lib/python3.4/asyncio/tasks.py", line 321, in _step
    result = next(coro)
  File "tests/list_commands_test.py", line 30, in test_blpop
    other = yield from create_redis('localhost', self.redis_port, loop=self.loop)
  File "/home/nick/sources/python/aioredis/aioredis/commands/__init__.py", line 90, in create_redis
    conn = yield from create_connection(address, db, password, loop=loop)
  File "/home/nick/sources/python/aioredis/aioredis/connection.py", line 36, in create_connection
    address, loop=loop)
  File "/usr/lib/python3.4/asyncio/streams.py", line 114, in open_unix_connection
    lambda: protocol, path, **kwds)
  File "/usr/lib/python3.4/asyncio/unix_events.py", line 188, in create_unix_connection
    yield from self.sock_connect(sock, path)
  File "/usr/lib/python3.4/asyncio/futures.py", line 350, in __iter__
    return self.result()  # May raise too.
  File "/usr/lib/python3.4/asyncio/futures.py", line 243, in result
    raise self._exception
  File "/usr/lib/python3.4/asyncio/selector_events.py", line 295, in _sock_connect
    sock.connect(address)
FileNotFoundError: [Errno 2] No such file or directory
```

So I added new connection creation to `setUp()` and everithing works just fine.
Is this something with my `redis`?
