### PR TITLE
100% coverage for list and scripting commands

### DIFF
--- a/tests/list_commands_test.py
+++ b/tests/list_commands_test.py
@@ -33,10 +33,10 @@ class ListCommandsTest(BaseTest):
 
         with self.assertRaises(TypeError):
             yield from self.redis.blpop(None)
-
+        with self.assertRaises(TypeError):
+            yield from self.redis.blpop(key1, None)
         with self.assertRaises(TypeError):
             yield from self.redis.blpop(key1, timeout=b'one')
-
         with self.assertRaises(ValueError):
             yield from self.redis.blpop(key2, timeout=-10)
 
@@ -91,10 +91,10 @@ class ListCommandsTest(BaseTest):
 
         with self.assertRaises(TypeError):
             yield from self.redis.brpop(None)
-
+        with self.assertRaises(TypeError):
+            yield from self.redis.brpop(key1, None)
         with self.assertRaises(TypeError):
             yield from self.redis.brpop(key1, timeout=b'one')
-
         with self.assertRaises(ValueError):
             yield from self.redis.brpop(key2, timeout=-10)
 

--- a/tests/scripting_commands_test.py
+++ b/tests/scripting_commands_test.py
@@ -32,9 +32,10 @@ class SetCommandsTest(RedisTest):
 
         with self.assertRaises(TypeError):
             yield from self.redis.eval(script, keys=['valid', None])
-
         with self.assertRaises(TypeError):
-            yield from self.redis.eval(script, args='not:list')
+            yield from self.redis.eval(script, args=['valid', None])
+        with self.assertRaises(TypeError):
+            yield from self.redis.eval(None)
 
     @run_until_complete
     def test_evalsha(self):
@@ -53,11 +54,11 @@ class SetCommandsTest(RedisTest):
         with self.assertRaises(ValueError):
             yield from self.redis.evalsha(b'wrong sha hash')
         with self.assertRaises(TypeError):
-            yield from self.redis.evalsha(sha_hash, keys='not:list')
-        with self.assertRaises(TypeError):
             yield from self.redis.evalsha(sha_hash, keys=['valid', None])
         with self.assertRaises(TypeError):
-            yield from self.redis.evalsha(sha_hash, args='not:list')
+            yield from self.redis.evalsha(sha_hash, args=['valid', None])
+        with self.assertRaises(TypeError):
+            yield from self.redis.evalsha(None)
 
     @run_until_complete
     def test_script_exists(self):


### PR DESCRIPTION
I noticed that coverage for _list_ and _scripting_ commands had been dropped. Here tiny fixes to bring back coverage 100%. 
Please review.
