### PR TITLE
Remove benchmarks since not the right lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,6 @@ The easiest way to install aioredis is by using the package on PyPi:
 -   Python 3.6+
 -   hiredis
 
-## Benchmarks
-
-Benchmarks can be found here:
-<https://github.com/popravich/python-redis-benchmark>
-
 ## Contribute
 
 -   Issue Tracker: <https://github.com/aio-libs/aioredis/issues>


### PR DESCRIPTION
This simply removes benchmarks link in the README since they don't align with current package at the moment.

-----
[View rendered README.md](https://github.com/aio-libs/aioredis-py/blob/Andrew-Chen-Wang-patch-1/README.md)