### PR TITLE
Replace distutils.versions with packaging.versions

### DIFF
--- a/CHANGES/1306.feature
+++ b/CHANGES/1306.feature
@@ -1,0 +1,1 @@
+Replace `disutils.version.StrictVersion` with `packaging.version.parse` implementation

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -36,6 +36,7 @@ Ilya Samartsev
 Ivan Antonyuck
 James Hilliard
 Jan Špaček
+Janos Molnar
 Jeff Moser
 Joongi Kim <achimnol>
 Kyrylo Dehtyarenko

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -8,7 +8,6 @@ import socket
 import ssl
 import threading
 import warnings
-from distutils.version import StrictVersion
 from itertools import chain
 from types import MappingProxyType
 from typing import (
@@ -28,6 +27,7 @@ from typing import (
 from urllib.parse import ParseResult, parse_qs, unquote, urlparse
 
 import async_timeout
+from packaging.version import parse as parse_version
 
 from .compat import Protocol, TypedDict
 from .exceptions import (
@@ -65,8 +65,8 @@ except (ImportError, ModuleNotFoundError):
     HIREDIS_AVAILABLE = False
 else:
     HIREDIS_AVAILABLE = True
-    hiredis_version = StrictVersion(hiredis.__version__)
-    if hiredis_version < StrictVersion("1.0.0"):
+    hiredis_version = parse_version(hiredis.__version__)
+    if hiredis_version < parse_version("1.0.0"):
         warnings.warn(
             "aioredis supports hiredis @ 1.0.0 or higher. "
             f"You have hiredis @ {hiredis.__version__}. "

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,87 @@
 
 # Changelog
 
+### Features
+
+- Replace PubSub.run_in_thread with a coroutine PubSub.run.
+  (see #1007)
+- Add redis-py commit bc5854217b4e94eb7a33e3da5738858a17135ca5
+  (see #1036)
+- Add redis-py commit https://github.com/andymccurdy/redis-py/commit/c7e26ae6749f63b9ebf65c023f270b2ea2b9536a
+  (see #1037)
+- Introduce issue forms
+  (see #1080)
+- Add auto_close_connection_pool for Redis-created connection pools, not manually created pools
+  (see #1256)
+- Using coroutines as callbacks is now possible.
+  (see #1284)
+- Replace `disutils.version.StrictVersion` with `packaging.version.parse` implementation
+  (see #1306)
+
+
+### Bugfixes
+
+- removed socket timeout setup
+  (see #951)
+- Fix a number of type annotations. The majority of the changes are to allow keys
+  to be specified as `bytes`, but other errors have been corrected too.
+  (see #1008)
+- Fix aioredis.lock.Lock using a sleep that blocks the event loop.
+  (see #1016)
+- include CHANGELOG.md in the sdist
+  (see #1043)
+- Skip testing with pypy and uvloop
+  (see #1045)
+- Set socket_connect_timeout in UnixDomainSocketConnection. Change `_connect` in UnixDomainSocketConnection to use socket_connect_timeout instead of socket_timeout.
+  (see #1060)
+- Rename the health check
+  (see #1065)
+- Adds a lock to ``aioredis.connection.ConnectionPool``
+  (see #1068)
+- Fix type annotations: added `typing.Optional` for values with default `None`.
+  (see #1083)
+- Restore mkdocs-autorefs to version 0.2.1 to remain compatible with mkdocstrings.
+  (see #1084)
+- Synchronized reading the responses from a connection
+  (see #1105)
+- fixed raw socket.error (or one of its subclasses) raises instead of a redis.exceptions.ConnectionError
+  (see #1129)
+- Fix type annotation of `socket_keepalive_options` arguments when creating connections and clients
+  (see #1141)
+- Fix buffer is closed error when using PythonParser class
+  (see #1212)
+- Fix typing on evalsha keys_and_args argument
+  (see #1214)
+- Fix typing on blpop (etc) timeout argument
+  (see #1224)
+- Change `__del__` in Redis to raise ResourceWarning (Fixes #1115)
+  (see #1227)
+- Instantiate lock on UnixDomainSocketConnection init.
+  (see #1249)
+
+
+### Improved Documentation
+
+- Document breaking API changes in redis 2.x.
+  (see #1109)
+- Fix errors in getting started examples; Unify style of getting started examples with other examples.
+  (see #1159)
+- Add the rest of the requirements
+  (see #1167)
+
+
+### Deprecations and Removals
+
+- Remove explicit loop arguments from connection classes.
+  Add loop argument to PubSub.run_in_thread.
+  (see #1002)
+
+
+### Misc
+
+- #930, #940, #1003, #1018, #1095, #1101, #1219, #1247, #1302
+
+
 ## 2.0.0a1 - (2021-06-18)
 
 ### Bugfixes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
 import argparse
 import asyncio
 import random
-from distutils.version import StrictVersion
 from typing import Callable, TypeVar
 from urllib.parse import urlparse
 
 import pytest
+from packaging.version import parse as parse_version
 
 import aioredis
 from aioredis.client import Monitor
@@ -117,13 +117,13 @@ def pytest_sessionstart(session):
 
 def skip_if_server_version_lt(min_version: str) -> _TestDecorator:
     redis_version = REDIS_INFO["version"]
-    check = StrictVersion(redis_version) < StrictVersion(min_version)
+    check = parse_version(redis_version) < parse_version(min_version)
     return pytest.mark.skipif(check, reason=f"Redis version required >= {min_version}")
 
 
 def skip_if_server_version_gte(min_version: str) -> _TestDecorator:
     redis_version = REDIS_INFO["version"]
-    check = StrictVersion(redis_version) >= StrictVersion(min_version)
+    check = parse_version(redis_version) >= parse_version(min_version)
     return pytest.mark.skipif(check, reason=f"Redis version required < {min_version}")
 
 
@@ -301,7 +301,7 @@ async def wait_for_command(client: aioredis.Redis, monitor: Monitor, command: st
     # if we find a command with our key before the command we're waiting
     # for, something went wrong
     redis_version = REDIS_INFO["version"]
-    if StrictVersion(redis_version) >= StrictVersion("5.0.0"):
+    if parse_version(redis_version) >= parse_version("5.0.0"):
         id_str = str(await client.client_id())
     else:
         id_str = "%08x" % random.randrange(2**32)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
This removes `DeprecationWarnings` raised by `distutils`.
Fixes #1306

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No changes to the user, besides not getting the `DeprecationWarnings`
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
#1306
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`


-----
[View rendered docs/changelog.md](https://github.com/tier-jani/aioredis-py/blob/replace-distutils-versions-with-packaging-versions/docs/changelog.md)