### PR TITLE
Restore connection on network errors

### DIFF
--- a/CHANGES/1314.bugfix
+++ b/CHANGES/1314.bugfix
@@ -1,0 +1,1 @@
+Drop broken connections after network errors

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -816,10 +816,8 @@ class Connection:
     def force_disconnect(self):
         """Force close reader and writer"""
         if os.getpid() == self.pid:
-            if not self.is_connected:
-                return
-
             self._reader = None
+            self._parser.on_disconnect()
 
             if self._writer:
                 try:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 async-timeout==4.0.2
-coverage==6.3.1
+coverage==6.2
 flake8==4.0.1
 hiredis==2.0.0
 mock==4.0.3

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -164,14 +164,16 @@ class TestConnectionPool:
 
         await pool.release(c1)
 
-        with mock.patch.object(c1, 'disconnect', wraps=c1.disconnect) as wrapped_foo:
+        with mock.patch.object(c1, "disconnect", wraps=c1.disconnect) as wrapped_foo:
             c2 = await pool.get_connection("_")
             wrapped_foo.assert_called_once()
 
         assert c1 == c2
         assert c1.is_connected
 
-    async def test_broken_connection_is_replaced_if_error_set_and_disconnect_failed(self, master_host):
+    async def test_broken_connection_is_replaced_if_error_set_and_disconnect_failed(
+        self, master_host
+    ):
         connection_kwargs = {"host": master_host}
         pool = self.get_pool(connection_kwargs=connection_kwargs)
 
@@ -180,7 +182,7 @@ class TestConnectionPool:
 
         await pool.release(c1)
 
-        with mock.patch.object(c1, 'disconnect', side_effect=asyncio.CancelledError()):
+        with mock.patch.object(c1, "disconnect", side_effect=asyncio.CancelledError()):
             c2 = await pool.get_connection("_")
 
         assert c1 != c2


### PR DESCRIPTION
## Problem

If the application is isolated from the Internet, and then access to the Internet is returned, it will no longer recover due to the fact that it will use broken connections.

## What do these changes do?

Broken connections in which the StreamReader has an exception (e.g. `OSError No route to host`) are removed from the connection pool and are no longer reused.

## Are there changes in behavior for the user?

Broken connections will be removed from connection pools.
