### PR TITLE
I think I found a fix for ConnectionResetError bug

### DIFF
--- a/aioredis/client.py
+++ b/aioredis/client.py
@@ -1104,7 +1104,7 @@ class Redis:
             return await self.parse_response(conn, command_name, **options)
         except (ConnectionError, TimeoutError) as e:
             await conn.disconnect()
-            if not (conn.retry_on_timeout and isinstance(e, TimeoutError)):
+            if isinstance(e, TimeoutError) and not conn.retry_on_timeout:
                 raise
             await conn.send_command(*args)
             return await self.parse_response(conn, command_name, **options)


### PR DESCRIPTION
Hi, Thanks for the amazing library, I recently encountered ConnectionResetError bug and found https://github.com/aio-libs/aioredis-py/issues/778 .
so I tried to make a fix.

https://github.com/aio-libs/aioredis-py/issues/778#issuecomment-984577902
I tested with above code (provided by [Enchufa2](https://github.com/Enchufa2)), this change fixes the problem :)

## What do these changes do?

now `Redis.execute_command()` catches `ConnectionAbort` and retry execution. 

## Are there changes in behavior for the user?

users do not have to except ConnectionError everytime they execute a command. Since RedisClient catches it for them.

## Related issue number

https://github.com/aio-libs/aioredis-py/issues/778
## Checklist

I'm trying to add an unit test! please wait a moment :)
if this change looks good for you, I'll also add myself to `CONTRIBUTORS.txt`
let me know what you think!

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
