### PR TITLE
Remove redundant TimeoutError class

### DIFF
--- a/CHANGES/1443.bugfix
+++ b/CHANGES/1443.bugfix
@@ -1,0 +1,1 @@
+Remove the `builtins.TimeoutError` class from base classes of `aioredis.exceptions.TimeoutError` because it is causing an error due to its redundancy.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -48,6 +48,7 @@ Martin <the-panda>
 Maxim Dodonchuk
 Michael Käufl
 Mikhail Solomenik
+Mohamed Farahat
 Nickolai Novik
 Oleg Abramov
 Oleg Butuzov

--- a/aioredis/exceptions.py
+++ b/aioredis/exceptions.py
@@ -1,6 +1,5 @@
 """Core exceptions raised by the Redis client"""
 import asyncio
-import builtins
 
 
 class RedisError(Exception):

--- a/aioredis/exceptions.py
+++ b/aioredis/exceptions.py
@@ -11,7 +11,7 @@ class ConnectionError(RedisError):
     pass
 
 
-class TimeoutError(asyncio.TimeoutError, builtins.TimeoutError, RedisError):
+class TimeoutError(asyncio.TimeoutError, RedisError):
     pass
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Remove the `builtins.TimeoutError` class from base classes of `aioredis.exceptions.TimeoutError` because it is causing an error due to its redundancy.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No

<!-- Outline any notable behaviour for the end users. -->

## Related issue number
#1443 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
