### PR TITLE
Use Version (packaging) instead of StrictVersion (distutils)

### DIFF
--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -8,7 +8,7 @@ import socket
 import ssl
 import threading
 import warnings
-from distutils.version import StrictVersion
+from packaging.version import Version
 from itertools import chain
 from types import MappingProxyType
 from typing import (
@@ -65,8 +65,8 @@ except (ImportError, ModuleNotFoundError):
     HIREDIS_AVAILABLE = False
 else:
     HIREDIS_AVAILABLE = True
-    hiredis_version = StrictVersion(hiredis.__version__)
-    if hiredis_version < StrictVersion("1.0.0"):
+    hiredis_version = Version(hiredis.__version__)
+    if hiredis_version < Version("1.0.0"):
         warnings.warn(
             "aioredis supports hiredis @ 1.0.0 or higher. "
             f"You have hiredis @ {hiredis.__version__}. "


### PR DESCRIPTION
This PR removes the Deprectation Warning found when running tests:
```bash
DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
hiredis_version = StrictVersion(hiredis.__version__)
```
I just wanted to get rid of it. :)

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
