### PR TITLE
Fix Python 3.11 error

### DIFF
--- a/CHANGES/1490.bugfix
+++ b/CHANGES/1490.bugfix
@@ -1,0 +1,1 @@
+aioredis.TimeoutError inherits only builtins.TimeoutError when Python asyncio.TimeoutError == builtins.TimeoutError.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -37,6 +37,7 @@ Ivan Antonyuck
 James Hilliard
 Jan Špaček
 Jeff Moser
+Jeong, YunWon <youknowone>
 Joongi Kim <achimnol>
 Kyrylo Dehtyarenko
 Leonid Shvechikov

--- a/aioredis/exceptions.py
+++ b/aioredis/exceptions.py
@@ -10,9 +10,12 @@ class RedisError(Exception):
 class ConnectionError(RedisError):
     pass
 
-
-class TimeoutError(asyncio.TimeoutError, builtins.TimeoutError, RedisError):
-    pass
+if asyncio.TimeoutError is builtins.TimeoutError:  # >= Python 3.11
+    class TimeoutError(builtins.TimeoutError, RedisError):
+        pass
+else:
+    class TimeoutError(asyncio.TimeoutError, builtins.TimeoutError, RedisError):
+        pass
 
 
 class AuthenticationError(ConnectionError):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix `TypeError: duplicate base class TimeoutError` from Python 3.11

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No (unless users distinguish asyncio.TimeoutError and builtins.TimeoutError)

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

Fix #1489 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
